### PR TITLE
character description added

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,1 +1,3 @@
 A website for my favourite character is currently being built here!
+
+Ford Prefect (also called Ix) is a fictional character in The Hitchhiker's Guide to the Galaxy by the British author Douglas Adams. His role as Arthur Dent's friend – and rescuer, when the Earth is unexpectedly demolished to make way for a hyperspace bypass at the start of the story – is often expository, as Ford is an experienced galactic hitch-hiker and explains that he is actually an alien journalist, a field researcher for the titular Guide itself, and not an out-of-work actor from Guildford as he had hitherto claimed.


### PR DESCRIPTION
A character description of Ford Prefect has been stolen from Wikipedia.
fixes: #3 